### PR TITLE
Add the --[no]sort_networks CLI option

### DIFF
--- a/capirca/aclgen.py
+++ b/capirca/aclgen.py
@@ -135,6 +135,11 @@ def SetupFlags():
       None,
       'Use network address value as address name for platforms that support it.\n(default: \'%s\')'
       % config.defaults['immutable_address_names'])
+  flags.DEFINE_boolean(
+      'sort_networks',
+      None,
+      'Sort the networks within a network entry in the definitions file.\n(default: \'%s\')'
+      % config.defaults['sort_networks'])
 
 
 class Error(Exception):
@@ -169,7 +174,7 @@ def SkipLines(text, skip_line_func=False):
 
 
 def RenderFile(base_directory, input_file, output_directory, definitions,
-               exp_info, optimize, shade_check, write_files):
+               exp_info, optimize, shade_check, sort_networks, write_files):
   """Render a single file.
 
   Args:
@@ -181,6 +186,7 @@ def RenderFile(base_directory, input_file, output_directory, definitions,
               in that many weeks.
     optimize: a boolean indicating if we should turn on optimization or not.
     shade_check: should we raise an error if a term is completely shaded
+    sort_networks: sort networks definitions file or not.
     write_files: a list of file tuples, (output_file, acl_text), to write
   """
   logging.debug('rendering file: %s into %s', input_file,
@@ -224,7 +230,8 @@ def RenderFile(base_directory, input_file, output_directory, definitions,
   try:
     pol = policy.ParsePolicy(
         conf, definitions, optimize=optimize,
-        base_dir=base_directory, shade_check=shade_check)
+        base_dir=base_directory, shade_check=shade_check,
+        sort_networks=sort_networks)
   except policy.ShadingError as e:
     logging.warning('shading errors for %s:\n%s', input_file, e)
     return
@@ -566,6 +573,7 @@ def Run(
     ignore_directories,
     optimize,
     shade_check,
+    sort_networks,
     context
 ):
   definitions = None
@@ -591,6 +599,7 @@ def Run(
         exp_info,
         optimize,
         shade_check,
+        sort_networks,
         write_files)
   else:
     # render all files in parallel
@@ -676,6 +685,7 @@ def main(argv):
       configs['ignore_directories'],
       configs['optimize'],
       configs['shade_check'],
+      configs['sort_networks'],
       context
   )
 

--- a/capirca/lib/policy.py
+++ b/capirca/lib/policy.py
@@ -49,6 +49,7 @@ _FLEXIBLE_MATCH_START_OPTIONS = {'layer-3', 'layer-4', 'payload'}
 _LOGGING = set(('true', 'True', 'syslog', 'local', 'disable', 'log-both'))
 _OPTIMIZE = True
 _SHADE_CHECK = False
+_SORT_NETWORKS = True
 _MAX_TTL = 255
 _MIN_TTL = 0
 
@@ -224,8 +225,8 @@ class Policy(object):
               'no destination ports of the correct protocol for term %s' % (
                   term.name))
 
-      # If argument is true, we optimize, otherwise just sort addresses
-      term.AddressCleanup(_OPTIMIZE, self._NeedsAddressBook())
+      # If argument is true, we optimize, or sort (or not) addresses
+      term.AddressCleanup(_OPTIMIZE, _SORT_NETWORKS, self._NeedsAddressBook())
       term.SanityCheck()
       term.translated = True
 
@@ -1363,7 +1364,7 @@ class Term(object):
         raise InvalidTermTTLValue('Term %s contains invalid TTL: %s'
                                   % (self.name, self.ttl))
 
-  def AddressCleanup(self, optimize=True, addressbook=False):
+  def AddressCleanup(self, optimize=True, sort=True, addressbook=False):
     """Do Address and Port collapsing.
 
     Notes:
@@ -1372,11 +1373,15 @@ class Term(object):
 
     Args:
       optimize: boolean value indicating whether to optimize addresses
+      sort: boolean value indicating whether to sort addresses (if no optimize)
       addressbook: Boolean indicating if addressbook is used.
     """
     def cleanup(addresses, complement_addresses):
       if not optimize:
-        return nacaddr.SortAddrList(addresses)
+        if sort:
+          return nacaddr.SortAddrList(addresses)
+        else:
+          return addresses
       if addressbook:
         return nacaddr.CollapseAddrListPreserveTokens(addresses)
       else:
@@ -2680,7 +2685,7 @@ def ParseFile(filename, definitions=None, optimize=True, base_dir='',
 
 
 def ParsePolicy(data, definitions=None, optimize=True, base_dir='',
-                shade_check=False, filename=''):
+                shade_check=False, filename='', sort_networks=True):
   """Parse the policy in 'data', optionally provide a naming object.
 
   Parse a blob of policy text into a policy object.
@@ -2703,6 +2708,7 @@ def ParsePolicy(data, definitions=None, optimize=True, base_dir='',
       globals()['DEFINITIONS'] = naming.Naming(DEFAULT_DEFINITIONS)
     globals()['_OPTIMIZE'] = optimize
     globals()['_SHADE_CHECK'] = shade_check
+    globals()['_SORT_NETWORKS'] = sort_networks
 
     lexer = lex.lex()
 

--- a/capirca/utils/config.py
+++ b/capirca/utils/config.py
@@ -16,6 +16,7 @@ defaults = {
     'shade_check': False,
     'exp_info': 2,
     'immutable_address_names': False,
+    'sort_networks': True,
 }
 
 
@@ -44,6 +45,7 @@ def flags_to_dict(absl_flags):
       'shade_check': absl_flags.shade_check,
       'exp_info': absl_flags.exp_info,
       'immutable_address_names': absl_flags.immutable_address_names,
+      'sort_networks': absl_flags.sort_networks,
   }
 
   return {


### PR DESCRIPTION
Add the --[no]sort_networks CLI option, that together with --[no]optimize will keep original generated order of networks in networks definition files. This can be useful when migrating from one method of generation to another one, and comparing that the end result is the same.